### PR TITLE
Add basic ORDER BY support (#11)

### DIFF
--- a/src/Core/LogicalEntities/SqlOrderByColumn.cs
+++ b/src/Core/LogicalEntities/SqlOrderByColumn.cs
@@ -1,0 +1,23 @@
+namespace SqlBuildingBlocks.LogicalEntities;
+
+/// <summary>
+/// Represents a single column reference in an ORDER BY clause, along with its sort direction.
+/// </summary>
+public class SqlOrderByColumn
+{
+    public SqlOrderByColumn(string columnName, bool descending = false)
+    {
+        ColumnName = columnName ?? throw new ArgumentNullException(nameof(columnName));
+        Descending = descending;
+    }
+
+    /// <summary>
+    /// The name of the column to sort by.  May be table-qualified (e.g. "t.Name").
+    /// </summary>
+    public string ColumnName { get; }
+
+    /// <summary>
+    /// <c>true</c> = DESC order; <c>false</c> (default) = ASC order.
+    /// </summary>
+    public bool Descending { get; }
+}

--- a/src/Core/LogicalEntities/SqlSelectDefinition.cs
+++ b/src/Core/LogicalEntities/SqlSelectDefinition.cs
@@ -15,7 +15,7 @@ public class SqlSelectDefinition
 
     public SqlBinaryExpression? WhereClause { get; set; }
 
-    //TODO: Maltby - Need ORDER BY columns
+    public IList<SqlOrderByColumn> OrderBy { get; set; } = new List<SqlOrderByColumn>();
 
     public SqlLimitOffset? Limit { get; set; }
 

--- a/src/Core/OrderByList.cs
+++ b/src/Core/OrderByList.cs
@@ -1,13 +1,16 @@
 ﻿using Irony.Parsing;
 using SqlBuildingBlocks.Extensions;
+using SqlBuildingBlocks.LogicalEntities;
 using System.Reflection;
 
 namespace SqlBuildingBlocks;
 
 public class OrderByList : NonTerminal
 {
+    private const string sOrderClauseOpt = "orderClauseOpt";
+
     /// <summary>
-    /// Helper ctor that assumes default <see cref="NonTerminal"/> types.  If you need different building blocks internally, use other ctor. 
+    /// Helper ctor that assumes default <see cref="NonTerminal"/> types.  If you need different building blocks internally, use other ctor.
     /// </summary>
     /// <param name="grammar"></param>
     public OrderByList(Grammar grammar) : this(grammar, new Id(grammar)) { }
@@ -15,6 +18,8 @@ public class OrderByList : NonTerminal
     public OrderByList(Grammar grammar, Id id)
         : base(TermName)
     {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+
         var COMMA = grammar.ToTerm(",");
 
         var orderByDirOpt = new NonTerminal("orderDirOpt");
@@ -26,5 +31,50 @@ public class OrderByList : NonTerminal
         Rule = grammar.MakePlusRule(this, COMMA, orderByMember);
     }
 
+    public Id Id { get; }
+
     private static string TermName => MethodBase.GetCurrentMethod().DeclaringType.Name.CamelCase();
+
+    /// <summary>
+    /// Converts an <c>orderClauseOpt</c> parse-tree node into a list of <see cref="SqlOrderByColumn"/>.
+    /// Returns an empty list when the clause is absent.
+    /// </summary>
+    /// <param name="orderClauseOpt">The <c>orderClauseOpt</c> child node of a <c>selectStmt</c> node.</param>
+    public virtual IList<SqlOrderByColumn> Create(ParseTreeNode orderClauseOpt)
+    {
+        if (orderClauseOpt.Term.Name != sOrderClauseOpt)
+            throw new ArgumentException(
+                $"Expected a '{sOrderClauseOpt}' node but received '{orderClauseOpt.Term.Name}'.",
+                nameof(orderClauseOpt));
+
+        // Empty ORDER BY clause (grammar.Empty matched)
+        if (orderClauseOpt.ChildNodes.Count == 0)
+            return new List<SqlOrderByColumn>();
+
+        // orderClauseOpt → "ORDER" + BY + orderByList  (children [0]=ORDER, [1]=BY, [2]=orderByList)
+        var orderByListNode = orderClauseOpt.ChildNodes[2];
+
+        var result = new List<SqlOrderByColumn>();
+        foreach (var orderByMember in orderByListNode.ChildNodes)
+        {
+            // orderByMember → id + orderDirOpt
+            var idNode = orderByMember.ChildNodes[0];
+            var dirNode = orderByMember.ChildNodes[1];
+
+            var columnBaseValues = Id.GetColumnBaseValues(idNode);
+
+            // Build the column name the same way GetOutputColumnName does:
+            // prefer table-qualified form so callers can strip it if needed.
+            string columnName = columnBaseValues.TableName != null
+                ? $"{columnBaseValues.TableName}.{columnBaseValues.ColumnName}"
+                : columnBaseValues.ColumnName;
+
+            bool descending = dirNode.ChildNodes.Count > 0 &&
+                              string.Equals(dirNode.ChildNodes[0].Term.Name, "DESC", StringComparison.OrdinalIgnoreCase);
+
+            result.Add(new SqlOrderByColumn(columnName, descending));
+        }
+
+        return result;
+    }
 }

--- a/src/Core/QueryProcessing/QueryEngine.cs
+++ b/src/Core/QueryProcessing/QueryEngine.cs
@@ -83,6 +83,10 @@ public class QueryEngine : IQueryEngine
                                     //FROM with JOINs
                                     ResolveSelectColumns(processingState, fromDataRows);
 
+        //Apply ORDER BY before LIMIT/OFFSET so that LIMIT operates on the sorted result set.
+        if (sqlSelectDefinition.OrderBy != null && sqlSelectDefinition.OrderBy.Count > 0)
+            selectRows = ApplyOrderBy(selectRows, sqlSelectDefinition.OrderBy);
+
         //TODO:  Maltby - There are lots of optimization possibilities here in the table joins
         if (sqlSelectDefinition.Limit != null && sqlSelectDefinition.Limit.RowOffset.Value > 0)
             selectRows = selectRows.Skip(sqlSelectDefinition.Limit.RowOffset.Value);
@@ -331,6 +335,36 @@ public class QueryEngine : IQueryEngine
 
         processingState.WhereApplied = sqlSelectDefinition.Table;
         return applyFilterMethodReturnValue;
+    }
+
+    private static IEnumerable<DataRow> ApplyOrderBy(IEnumerable<DataRow> rows, IList<SqlOrderByColumn> orderBy)
+    {
+        var first = orderBy[0];
+        var firstColName = GetColumnName(first.ColumnName);
+
+        IOrderedEnumerable<DataRow> ordered = first.Descending
+            ? rows.OrderByDescending(row => row[firstColName], Comparer<object>.Create(CompareValues))
+            : rows.OrderBy(row => row[firstColName], Comparer<object>.Create(CompareValues));
+
+        for (int i = 1; i < orderBy.Count; i++)
+        {
+            var col = orderBy[i];
+            var colName = GetColumnName(col.ColumnName);
+            ordered = col.Descending
+                ? ordered.ThenByDescending(row => row[colName], Comparer<object>.Create(CompareValues))
+                : ordered.ThenBy(row => row[colName], Comparer<object>.Create(CompareValues));
+        }
+
+        return ordered;
+    }
+
+    private static int CompareValues(object x, object y)
+    {
+        if (x == DBNull.Value && y == DBNull.Value) return 0;
+        if (x == DBNull.Value) return -1;
+        if (y == DBNull.Value) return 1;
+        if (x is IComparable cx) return cx.CompareTo(y);
+        return string.Compare(x.ToString(), y.ToString(), StringComparison.Ordinal);
     }
 
     private bool WhereClauseContainsOnlyTables(SqlBinaryExpression whereClause, HashSet<SqlTable> tables)

--- a/src/Core/SelectStmt.cs
+++ b/src/Core/SelectStmt.cs
@@ -143,6 +143,10 @@ public class SelectStmt : NonTerminal
 
         //WHERE clause
         sqlSelectDefinition.WhereClause = WhereClauseOpt?.Create(selectStmt.ChildNodes[5]);
+
+        //ORDER BY clause
+        if (OrderByList != null)
+            sqlSelectDefinition.OrderBy = OrderByList.Create(selectStmt.ChildNodes[8]);
     }
 
 

--- a/tests/Core.Tests/OrderByListTests.cs
+++ b/tests/Core.Tests/OrderByListTests.cs
@@ -1,4 +1,7 @@
-﻿using Irony.Parsing;
+using Irony.Parsing;
+using SqlBuildingBlocks.Core.Tests.Utils;
+using SqlBuildingBlocks.LogicalEntities;
+using Xunit;
 
 namespace SqlBuildingBlocks.Core.Tests;
 
@@ -6,7 +9,6 @@ public class OrderByListTests
 {
     private class TestGrammar : Grammar
     {
-
         public TestGrammar()
         {
             var simpleId = new SimpleId(this);
@@ -17,5 +19,89 @@ public class OrderByListTests
         }
     }
 
-    //[Fact]
+    [Fact]
+    public void SelectStmt_OrderBy_SingleColumn_Asc_IsPopulated()
+    {
+        SelectStmtTests.TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "SELECT id, city FROM locations ORDER BY id ASC");
+
+        var selectDef = ((SelectStmt)grammar.Root).Create(node);
+
+        Assert.NotNull(selectDef.OrderBy);
+        Assert.Single(selectDef.OrderBy);
+        Assert.Equal("id", selectDef.OrderBy[0].ColumnName);
+        Assert.False(selectDef.OrderBy[0].Descending);
+    }
+
+    [Fact]
+    public void SelectStmt_OrderBy_SingleColumn_Desc_IsPopulated()
+    {
+        SelectStmtTests.TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "SELECT id, city FROM locations ORDER BY city DESC");
+
+        var selectDef = ((SelectStmt)grammar.Root).Create(node);
+
+        Assert.NotNull(selectDef.OrderBy);
+        Assert.Single(selectDef.OrderBy);
+        Assert.Equal("city", selectDef.OrderBy[0].ColumnName);
+        Assert.True(selectDef.OrderBy[0].Descending);
+    }
+
+    [Fact]
+    public void SelectStmt_OrderBy_MultiColumn_IsPopulated()
+    {
+        SelectStmtTests.TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "SELECT id, city, state FROM locations ORDER BY state ASC, city DESC");
+
+        var selectDef = ((SelectStmt)grammar.Root).Create(node);
+
+        Assert.NotNull(selectDef.OrderBy);
+        Assert.Equal(2, selectDef.OrderBy.Count);
+
+        Assert.Equal("state", selectDef.OrderBy[0].ColumnName);
+        Assert.False(selectDef.OrderBy[0].Descending);
+
+        Assert.Equal("city", selectDef.OrderBy[1].ColumnName);
+        Assert.True(selectDef.OrderBy[1].Descending);
+    }
+
+    [Fact]
+    public void SelectStmt_OrderBy_TableQualified_IsPopulated()
+    {
+        SelectStmtTests.TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "SELECT l.id, l.city FROM locations l ORDER BY l.id ASC");
+
+        var selectDef = ((SelectStmt)grammar.Root).Create(node);
+
+        Assert.NotNull(selectDef.OrderBy);
+        Assert.Single(selectDef.OrderBy);
+        Assert.Equal("l.id", selectDef.OrderBy[0].ColumnName);
+        Assert.False(selectDef.OrderBy[0].Descending);
+    }
+
+    [Fact]
+    public void SelectStmt_NoOrderBy_ReturnsEmptyList()
+    {
+        SelectStmtTests.TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "SELECT id, city FROM locations");
+
+        var selectDef = ((SelectStmt)grammar.Root).Create(node);
+
+        Assert.NotNull(selectDef.OrderBy);
+        Assert.Empty(selectDef.OrderBy);
+    }
+
+    [Fact]
+    public void SelectStmt_OrderBy_ImplicitAsc_IsNotDescending()
+    {
+        SelectStmtTests.TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "SELECT id, city FROM locations ORDER BY city");
+
+        var selectDef = ((SelectStmt)grammar.Root).Create(node);
+
+        Assert.NotNull(selectDef.OrderBy);
+        Assert.Single(selectDef.OrderBy);
+        Assert.Equal("city", selectDef.OrderBy[0].ColumnName);
+        Assert.False(selectDef.OrderBy[0].Descending);
+    }
 }

--- a/tests/Core.Tests/QueryProcessing/QueryEngineTests.cs
+++ b/tests/Core.Tests/QueryProcessing/QueryEngineTests.cs
@@ -317,6 +317,197 @@ public class QueryEngineTests
     }
 
     [Fact]
+    public void QueryAsDataTable_OrderBy_SingleColumn_Asc()
+    {
+        const string databaseName = "MyDB";
+
+        // SELECT id, city FROM locations ORDER BY city ASC
+        SqlSelectDefinition sqlSelect = new();
+        SqlColumn idCol = new(databaseName, "locations", "id") { ColumnType = typeof(int) };
+        SqlColumn cityCol = new(databaseName, "locations", "city") { ColumnType = typeof(string) };
+        sqlSelect.Columns.Add(idCol);
+        sqlSelect.Columns.Add(cityCol);
+
+        SqlTable locationsTable = new(databaseName, "locations");
+        idCol.TableRef = locationsTable;
+        cityCol.TableRef = locationsTable;
+        sqlSelect.Table = locationsTable;
+
+        sqlSelect.OrderBy.Add(new SqlOrderByColumn("city", descending: false));
+
+        DataSet dataSet = new(databaseName);
+        DataTable locations = new("locations");
+        locations.Columns.Add("id", typeof(int));
+        locations.Columns.Add("city", typeof(string));
+        locations.Rows.Add(1, "Houston");
+        locations.Rows.Add(2, "New Braunfels");
+        locations.Rows.Add(3, "Austin");
+        dataSet.Tables.Add(locations);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+        var resultset = queryEngine.QueryAsDataTable();
+
+        Assert.Equal(3, resultset.Rows.Count);
+        Assert.Equal("Austin", resultset.Rows[0]["city"]);
+        Assert.Equal("Houston", resultset.Rows[1]["city"]);
+        Assert.Equal("New Braunfels", resultset.Rows[2]["city"]);
+    }
+
+    [Fact]
+    public void QueryAsDataTable_OrderBy_SingleColumn_Desc()
+    {
+        const string databaseName = "MyDB";
+
+        // SELECT id, city FROM locations ORDER BY city DESC
+        SqlSelectDefinition sqlSelect = new();
+        SqlColumn idCol = new(databaseName, "locations", "id") { ColumnType = typeof(int) };
+        SqlColumn cityCol = new(databaseName, "locations", "city") { ColumnType = typeof(string) };
+        sqlSelect.Columns.Add(idCol);
+        sqlSelect.Columns.Add(cityCol);
+
+        SqlTable locationsTable = new(databaseName, "locations");
+        idCol.TableRef = locationsTable;
+        cityCol.TableRef = locationsTable;
+        sqlSelect.Table = locationsTable;
+
+        sqlSelect.OrderBy.Add(new SqlOrderByColumn("city", descending: true));
+
+        DataSet dataSet = new(databaseName);
+        DataTable locations = new("locations");
+        locations.Columns.Add("id", typeof(int));
+        locations.Columns.Add("city", typeof(string));
+        locations.Rows.Add(1, "Houston");
+        locations.Rows.Add(2, "New Braunfels");
+        locations.Rows.Add(3, "Austin");
+        dataSet.Tables.Add(locations);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+        var resultset = queryEngine.QueryAsDataTable();
+
+        Assert.Equal(3, resultset.Rows.Count);
+        Assert.Equal("New Braunfels", resultset.Rows[0]["city"]);
+        Assert.Equal("Houston", resultset.Rows[1]["city"]);
+        Assert.Equal("Austin", resultset.Rows[2]["city"]);
+    }
+
+    [Fact]
+    public void QueryAsDataTable_OrderBy_MultiColumn()
+    {
+        const string databaseName = "MyDB";
+
+        // SELECT id, state, city FROM locations ORDER BY state ASC, city DESC
+        SqlSelectDefinition sqlSelect = new();
+        SqlColumn idCol = new(databaseName, "locations", "id") { ColumnType = typeof(int) };
+        SqlColumn stateCol = new(databaseName, "locations", "state") { ColumnType = typeof(string) };
+        SqlColumn cityCol = new(databaseName, "locations", "city") { ColumnType = typeof(string) };
+        sqlSelect.Columns.Add(idCol);
+        sqlSelect.Columns.Add(stateCol);
+        sqlSelect.Columns.Add(cityCol);
+
+        SqlTable locationsTable = new(databaseName, "locations");
+        idCol.TableRef = locationsTable;
+        stateCol.TableRef = locationsTable;
+        cityCol.TableRef = locationsTable;
+        sqlSelect.Table = locationsTable;
+
+        sqlSelect.OrderBy.Add(new SqlOrderByColumn("state", descending: false));
+        sqlSelect.OrderBy.Add(new SqlOrderByColumn("city", descending: true));
+
+        DataSet dataSet = new(databaseName);
+        DataTable locations = new("locations");
+        locations.Columns.Add("id", typeof(int));
+        locations.Columns.Add("state", typeof(string));
+        locations.Columns.Add("city", typeof(string));
+        locations.Rows.Add(1, "Texas", "Houston");
+        locations.Rows.Add(2, "Texas", "Austin");
+        locations.Rows.Add(3, "California", "Los Angeles");
+        locations.Rows.Add(4, "California", "San Francisco");
+        dataSet.Tables.Add(locations);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+        var resultset = queryEngine.QueryAsDataTable();
+
+        Assert.Equal(4, resultset.Rows.Count);
+        // California first (ASC), cities within California in DESC order
+        Assert.Equal("San Francisco", resultset.Rows[0]["city"]);
+        Assert.Equal("Los Angeles", resultset.Rows[1]["city"]);
+        // Texas second, cities within Texas in DESC order
+        Assert.Equal("Houston", resultset.Rows[2]["city"]);
+        Assert.Equal("Austin", resultset.Rows[3]["city"]);
+    }
+
+    [Fact]
+    public void QueryAsDataTable_OrderBy_Numeric_Asc()
+    {
+        const string databaseName = "MyDB";
+
+        // SELECT id FROM locations ORDER BY id ASC — verifies numeric (not lexicographic) sort
+        SqlSelectDefinition sqlSelect = new();
+        SqlColumn idCol = new(databaseName, "locations", "id") { ColumnType = typeof(int) };
+        sqlSelect.Columns.Add(idCol);
+
+        SqlTable locationsTable = new(databaseName, "locations");
+        idCol.TableRef = locationsTable;
+        sqlSelect.Table = locationsTable;
+
+        sqlSelect.OrderBy.Add(new SqlOrderByColumn("id", descending: false));
+
+        DataSet dataSet = new(databaseName);
+        DataTable locations = new("locations");
+        locations.Columns.Add("id", typeof(int));
+        locations.Rows.Add(10);
+        locations.Rows.Add(2);
+        locations.Rows.Add(1);
+        dataSet.Tables.Add(locations);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+        var resultset = queryEngine.QueryAsDataTable();
+
+        Assert.Equal(3, resultset.Rows.Count);
+        Assert.Equal(1, resultset.Rows[0]["id"]);
+        Assert.Equal(2, resultset.Rows[1]["id"]);
+        Assert.Equal(10, resultset.Rows[2]["id"]);
+    }
+
+    [Fact]
+    public void QueryAsDataTable_OrderBy_Then_Limit()
+    {
+        const string databaseName = "MyDB";
+
+        // ORDER BY id ASC LIMIT 2 — verifies ordering applied before limiting
+        SqlSelectDefinition sqlSelect = new();
+        SqlColumn idCol = new(databaseName, "locations", "id") { ColumnType = typeof(int) };
+        SqlColumn cityCol = new(databaseName, "locations", "city") { ColumnType = typeof(string) };
+        sqlSelect.Columns.Add(idCol);
+        sqlSelect.Columns.Add(cityCol);
+
+        SqlTable locationsTable = new(databaseName, "locations");
+        idCol.TableRef = locationsTable;
+        cityCol.TableRef = locationsTable;
+        sqlSelect.Table = locationsTable;
+
+        sqlSelect.OrderBy.Add(new SqlOrderByColumn("id", descending: false));
+        sqlSelect.Limit = new SqlLimitOffset { RowCount = new SqlLimitValue(2) };
+
+        DataSet dataSet = new(databaseName);
+        DataTable locations = new("locations");
+        locations.Columns.Add("id", typeof(int));
+        locations.Columns.Add("city", typeof(string));
+        locations.Rows.Add(3, "Austin");
+        locations.Rows.Add(1, "Houston");
+        locations.Rows.Add(2, "New Braunfels");
+        dataSet.Tables.Add(locations);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+        var resultset = queryEngine.QueryAsDataTable();
+
+        // After sort: 1-Houston, 2-New Braunfels, 3-Austin.  LIMIT 2 → first two.
+        Assert.Equal(2, resultset.Rows.Count);
+        Assert.Equal(1, resultset.Rows[0]["id"]);
+        Assert.Equal(2, resultset.Rows[1]["id"]);
+    }
+
+    [Fact]
     public void QueryWithUnendingDataSource_Select()
     {
         SelectStmtTests.TestGrammar grammar = new();


### PR DESCRIPTION
## Summary

Resolves #11

Implements end-to-end ORDER BY support in the SQL parsing and query execution pipeline.

### Changes

**New logical entity**
- `SqlOrderByColumn` — represents a single ORDER BY column with a column name and sort direction (`Descending` flag)

**`SqlSelectDefinition`**
- Added `OrderBy` property (`IList<SqlOrderByColumn>`), replacing the existing `//TODO` comment

**`OrderByList`**
- Added `Create(orderClauseOptNode)` method that parses the `orderClauseOpt` parse-tree node into a list of `SqlOrderByColumn`, handling table-qualified names (`table.column`), implicit ASC, and empty clauses

**`SelectStmt`**
- `Update()` now reads child node `[8]` (`orderClauseOpt`) and assigns the result to `sqlSelectDefinition.OrderBy`

**`QueryEngine`**
- Added `ApplyOrderBy()` which sorts result rows **before** LIMIT/OFFSET is applied, using `IComparable` for correct numeric/string ordering and graceful `DBNull` handling
- Supports multi-column ordering via `ThenBy`/`ThenByDescending`

## Test plan

- [x] `OrderByListTests` — single-column ASC/DESC, multi-column, table-qualified names, implicit ASC, absent clause (empty list)
- [x] `QueryEngineTests` — single-column ASC, single-column DESC, multi-column, numeric (not lexicographic) sort, ORDER BY applied before LIMIT
- [x] All 124 existing tests continue to pass