### PR TITLE
Add Claude automatic PR code review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,39 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request. Focus on identifying critical issues related to:
+            - Potential bugs or correctness issues
+            - Security implications
+            - Performance considerations
+            - Code quality and best practices specific to C# SQL parsing / grammar / building blocks
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues inline.
+            Only post GitHub comments — don't submit review text as messages.
+            Skip minor stylistic suggestions unless they impact correctness, security, or performance.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically triggers Claude to review every PR when opened or updated
- Uses `anthropics/claude-code-action@v1` with progress tracking
- Reviews focus on bugs, security, performance, and C# SQL parsing/grammar best practices
- Posts inline comments and top-level PR comments

## Setup Required
Add `ANTHROPIC_API_KEY` as a repository secret (Settings → Secrets and variables → Actions → New repository secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)