### PR TITLE
feat: Add CAST(expr AS type) expression support (#20)

### DIFF
--- a/src/Core/Expr.cs
+++ b/src/Core/Expr.cs
@@ -13,6 +13,9 @@ public class Expr : NonTerminal
     private const string binExprTermName = "binExpr";
     private const string isNullExprTermName = "isNullExpr";
     private const string betweenExprTermName = "betweenExpr";
+    private const string castExprTermName = "castExpr";
+
+    private DataType? dataType;
 
     private readonly Grammar grammar;
     private FuncCall? funcCall;
@@ -47,9 +50,13 @@ public class Expr : NonTerminal
     /// <summary>
     /// Necessary to set the Rule here instead of in the ctor, due to a cycle in the definition of the Rule
     /// </summary>
-    public void InitializeRule(SelectStmt selectStmt, FuncCall funcCall)
+    public void InitializeRule(SelectStmt selectStmt, FuncCall funcCall) =>
+        InitializeRule(selectStmt, funcCall, new DataType(grammar));
+
+    public void InitializeRule(SelectStmt selectStmt, FuncCall funcCall, DataType dataType)
     {
         this.funcCall = funcCall ?? throw new ArgumentNullException(nameof(funcCall));
+        this.dataType = dataType ?? throw new ArgumentNullException(nameof(dataType));
 
         var NOT = grammar.ToTerm("NOT");
         var PLUS = grammar.ToTerm("+");
@@ -144,7 +151,15 @@ public class Expr : NonTerminal
 
         betweenArithOp.SetFlag(TermFlags.InheritPrecedence);
 
-        Rule = term | unExpr | binExpr | isNullExpr | betweenExpr;
+        // CAST(expr AS dataType) — parens, AS, and CAST keyword are punctuation so children = [expr, dataType]
+        var CAST = grammar.ToTerm("CAST");
+        var castExpr = new NonTerminal(castExprTermName);
+        castExpr.Rule = CAST + "(" + this + "AS" + dataType + ")";
+
+        grammar.MarkPunctuation(CAST);
+        grammar.MarkReservedWords("CAST");
+
+        Rule = term | unExpr | binExpr | isNullExpr | betweenExpr | castExpr;
 
         //Note: we cannot declare binOp as transient because it includes operators "NOT LIKE", "NOT IN" consisting of two tokens.
         // Transient non-terminals cannot have more than one non-punctuation child nodes.
@@ -176,6 +191,12 @@ public class Expr : NonTerminal
         if (nodeTermName == betweenExprTermName)
         {
             return new(CreateBetweenExpression(expression));
+        }
+
+        //Is this a CAST expression?
+        if (nodeTermName == castExprTermName)
+        {
+            return new(CreateCastExpression(expression));
         }
 
         //Is this node a column reference?
@@ -279,6 +300,21 @@ public class Expr : NonTerminal
         var op = isNotNull ? SqlBinaryOperator.IsNotNull : SqlBinaryOperator.IsNull;
 
         return new(left, op, null);
+    }
+
+    protected internal SqlCastExpression CreateCastExpression(ParseTreeNode castExprNode)
+    {
+        if (castExprNode.Term.Name != castExprTermName)
+        {
+            var thisMethod = MethodBase.GetCurrentMethod() as MethodInfo;
+            throw new ArgumentException($"Cannot create building block of type {thisMethod!.ReturnType}.  The TermName for node is {castExprNode.Term.Name} which does not match {castExprTermName}", nameof(castExprNode));
+        }
+
+        // Parens and AS are globally punctuation, so children = [expr, dataType]
+        var expression = Create(castExprNode.ChildNodes[0]);
+        var sqlDataType = dataType!.Create(castExprNode.ChildNodes[1]);
+
+        return new(expression, sqlDataType);
     }
 
     internal static SqlBinaryOperator CreateOperator(string sBinaryOperator) =>

--- a/src/Core/Interfaces/ISqlExpressionVisitor.cs
+++ b/src/Core/Interfaces/ISqlExpressionVisitor.cs
@@ -43,4 +43,10 @@ public interface ISqlExpressionVisitor
     /// <param name="column"></param>
     /// <returns>An expression which is the leaf node's replacement.  A <see cref="null"/> value implies no change.</returns>
     SqlExpression? Visit(SqlLiteralValue value);
+
+    /// <summary>
+    /// Visits the <see cref="SqlCastExpression"/> in the <see cref="SqlExpression"/> tree.
+    /// </summary>
+    /// <param name="castExpr"></param>
+    void Visit(SqlCastExpression castExpr);
 }

--- a/src/Core/LogicalEntities/SqlCastExpression.cs
+++ b/src/Core/LogicalEntities/SqlCastExpression.cs
@@ -1,0 +1,36 @@
+using SqlBuildingBlocks.Interfaces;
+
+namespace SqlBuildingBlocks.LogicalEntities;
+
+public class SqlCastExpression
+{
+    public SqlCastExpression(SqlExpression expression, SqlDataType dataType)
+    {
+        Expression = expression ?? throw new ArgumentNullException(nameof(expression));
+        DataType = dataType ?? throw new ArgumentNullException(nameof(dataType));
+    }
+
+    public SqlExpression Expression { get; }
+    public SqlDataType DataType { get; }
+
+    public void Accept(ISqlExpressionVisitor visitor)
+    {
+        visitor.Visit(this);
+        Expression.Accept(visitor);
+    }
+
+    public string ToExpressionString()
+    {
+        var dataTypeName = DataType.Name;
+        if (DataType.Length.HasValue)
+            dataTypeName += $"({DataType.Length})";
+        else if (DataType.Precision.HasValue && DataType.Scale.HasValue)
+            dataTypeName += $"({DataType.Precision},{DataType.Scale})";
+        else if (DataType.Precision.HasValue)
+            dataTypeName += $"({DataType.Precision})";
+
+        return $"CAST({Expression.ToExpressionString()} AS {dataTypeName})";
+    }
+
+    public override string ToString() => ToExpressionString();
+}

--- a/src/Core/LogicalEntities/SqlExpression.cs
+++ b/src/Core/LogicalEntities/SqlExpression.cs
@@ -14,6 +14,7 @@ public class SqlExpression
     public SqlExpression(SqlLiteralValue value) => Value = value;
     public SqlExpression(SqlBinaryExpression binExpr) => BinExpr = binExpr;
     public SqlExpression(SqlBetweenExpression betweenExpr) => BetweenExpr = betweenExpr;
+    public SqlExpression(SqlCastExpression castExpr) => CastExpr = castExpr;
 
     //Logic within this class should enforce that only one of these properties is ever set.
     public SqlColumnRef? Column { get; private set; }
@@ -22,6 +23,7 @@ public class SqlExpression
     public SqlLiteralValue? Value { get; private set; }
     public SqlBinaryExpression? BinExpr { get; private set; }
     public SqlBetweenExpression? BetweenExpr { get; private set; }
+    public SqlCastExpression? CastExpr { get; private set; }
 
     public Type Type 
     { 
@@ -62,6 +64,12 @@ public class SqlExpression
         if (BetweenExpr != null)
         {
             BetweenExpr.Accept(visitor);
+            return;
+        }
+
+        if (CastExpr != null)
+        {
+            CastExpr.Accept(visitor);
             return;
         }
 
@@ -200,6 +208,7 @@ public class SqlExpression
         Value = null;
         BinExpr = null;
         BetweenExpr = null;
+        CastExpr = null;
 
         if (expression.Column != null)
             Column = expression.Column;
@@ -213,12 +222,15 @@ public class SqlExpression
             BinExpr = expression.BinExpr;
         else if (expression.BetweenExpr != null)
             BetweenExpr = expression.BetweenExpr;
+        else if (expression.CastExpr != null)
+            CastExpr = expression.CastExpr;
     }
 
     public string ToExpressionString()
     {
         if (BinExpr != null) return BinExpr.ToExpressionString();
         if (BetweenExpr != null) return BetweenExpr.ToExpressionString();
+        if (CastExpr != null) return CastExpr.ToExpressionString();
         if (Column != null) return Column.ToExpressionString();
         if (Parameter != null) return Parameter.ToExpressionString();
         if (Function != null) return Function.ToExpressionString();
@@ -231,6 +243,7 @@ public class SqlExpression
     {
         if (BinExpr != null) return BinExpr.ToString();
         if (BetweenExpr != null) return BetweenExpr.ToString();
+        if (CastExpr != null) return CastExpr.ToString();
         if (Column != null) return Column.ToString();
         if (Parameter != null) return Parameter.ToString();
         if (Function != null) return Function.ToString();

--- a/src/Core/Visitors/ColumnRefsVisitor.cs
+++ b/src/Core/Visitors/ColumnRefsVisitor.cs
@@ -45,4 +45,6 @@ class ColumnRefsVisitor : ISqlExpressionVisitor
     public SqlExpression? Visit(SqlFunction function) => null;
 
     public SqlExpression? Visit(SqlLiteralValue value) => null;
+
+    public void Visit(SqlCastExpression castExpr) { }
 }

--- a/src/Core/Visitors/ContainsTablesVisitor.cs
+++ b/src/Core/Visitors/ContainsTablesVisitor.cs
@@ -41,4 +41,6 @@ class ContainsTablesVisitor : ISqlExpressionVisitor
     public SqlExpression? Visit(SqlFunction function) => null;
 
     public SqlExpression? Visit(SqlLiteralValue value) => null;
+
+    public void Visit(SqlCastExpression castExpr) { }
 }

--- a/src/Core/Visitors/FunctionsEncounteredVisitor.cs
+++ b/src/Core/Visitors/FunctionsEncounteredVisitor.cs
@@ -50,4 +50,6 @@ public class FunctionsEncounteredVisitor : ISqlExpressionVisitor
     }
 
     public SqlExpression? Visit(SqlLiteralValue value) => null;
+
+    public void Visit(SqlCastExpression castExpr) { }
 }

--- a/src/Core/Visitors/ResolveFunctionsVisitorBase.cs
+++ b/src/Core/Visitors/ResolveFunctionsVisitorBase.cs
@@ -30,6 +30,8 @@ public abstract class ResolveFunctionsVisitorBase : ISqlExpressionVisitor, ISqlV
 
     SqlLimitValue? ISqlValueVisitor.Visit(SqlLimitValue limit) => null;
 
+    public virtual void Visit(SqlCastExpression castExpr) { }
+
     protected abstract SqlExpression? VisitReturnExpression(SqlFunction sqlFunction);
 
     protected abstract SqlLiteralValue? VisitReturnValue(SqlFunction sqlFunction);

--- a/src/Core/Visitors/ResolveParametersVisitor.cs
+++ b/src/Core/Visitors/ResolveParametersVisitor.cs
@@ -87,6 +87,8 @@ public class ResolveParametersVisitor : ISqlExpressionVisitor, ISqlValueVisitor
 
     public SqlExpression? Visit(SqlLiteralValue value) => null;
 
+    public void Visit(SqlCastExpression castExpr) { }
+
     public SqlLimitValue? Visit(SqlLimitValue limit)
     {
         if (limit.Parameter != null)

--- a/tests/Core.Tests/ExprTests.cs
+++ b/tests/Core.Tests/ExprTests.cs
@@ -304,4 +304,60 @@ public class ExprTests
         Assert.Equal("age NOT BETWEEN 18 AND 25", expression.ToExpressionString());
     }
 
+    // ── CAST ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Cast_ColumnToVarchar()
+    {
+        TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "CAST(order_id AS VARCHAR(50))");
+        var expression = grammar.Create(node);
+
+        Assert.NotNull(expression.CastExpr);
+        var cast = expression.CastExpr!;
+
+        Assert.NotNull(cast.Expression.Column);
+        Assert.Equal("order_id", cast.Expression.Column.ColumnName);
+
+        Assert.Equal("VARCHAR", cast.DataType.Name);
+        Assert.Equal(50, cast.DataType.Length);
+    }
+
+    [Fact]
+    public void Cast_ColumnToInt()
+    {
+        TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "CAST(price AS INT)");
+        var expression = grammar.Create(node);
+
+        Assert.NotNull(expression.CastExpr);
+        var cast = expression.CastExpr!;
+
+        Assert.NotNull(cast.Expression.Column);
+        Assert.Equal("price", cast.Expression.Column.ColumnName);
+
+        Assert.Equal("INT", cast.DataType.Name);
+        Assert.Null(cast.DataType.Length);
+    }
+
+    [Fact]
+    public void Cast_ToExpressionString_WithLength()
+    {
+        TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "CAST(order_id AS VARCHAR(50))");
+        var expression = grammar.Create(node);
+
+        Assert.Equal("CAST(order_id AS VARCHAR(50))", expression.ToExpressionString());
+    }
+
+    [Fact]
+    public void Cast_ToExpressionString_NoParams()
+    {
+        TestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar, "CAST(price AS INT)");
+        var expression = grammar.Create(node);
+
+        Assert.Equal("CAST(price AS INT)", expression.ToExpressionString());
+    }
+
 }

--- a/tests/Core.Tests/SqlBuildingBlocks.Core.Tests.csproj
+++ b/tests/Core.Tests/SqlBuildingBlocks.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Core.Tests/Utils/DetectVisitedVisitor.cs
+++ b/tests/Core.Tests/Utils/DetectVisitedVisitor.cs
@@ -2,6 +2,7 @@
 using SqlBuildingBlocks.LogicalEntities;
 using Xunit;
 
+
 namespace SqlBuildingBlocks.Core.Tests.Utils;
 
 internal class DetectVisitedVisitor : ISqlExpressionVisitor
@@ -52,4 +53,6 @@ internal class DetectVisitedVisitor : ISqlExpressionVisitor
         VisitedValue = true;
         return null;
     }
+
+    public void Visit(SqlCastExpression castExpr) { }
 }

--- a/tests/Grammars/AnsiSQL.Tests/SqlBuildingBlocks.Grammars.AnsiSQL.Tests.csproj
+++ b/tests/Grammars/AnsiSQL.Tests/SqlBuildingBlocks.Grammars.AnsiSQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Grammars/CrossCutting.Tests/SqlBuildingBlocks.Grammars.CrossCutting.Tests.csproj
+++ b/tests/Grammars/CrossCutting.Tests/SqlBuildingBlocks.Grammars.CrossCutting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Grammars/MySQL.Tests/SqlBuildingBlocks.Grammars.MySQL.Tests.csproj
+++ b/tests/Grammars/MySQL.Tests/SqlBuildingBlocks.Grammars.MySQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Grammars/PostgreSQL.Tests/SqlBuildingBlocks.Grammars.PostgreSQL.Tests.csproj
+++ b/tests/Grammars/PostgreSQL.Tests/SqlBuildingBlocks.Grammars.PostgreSQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Grammars/SQLServer.Tests/SqlBuildingBlocks.Grammars.SQLServer.Tests.csproj
+++ b/tests/Grammars/SQLServer.Tests/SqlBuildingBlocks.Grammars.SQLServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- New `SqlCastExpression` class holding `Expression: SqlExpression` and `DataType: SqlDataType`
- Grammar reuses the existing `DataType` NonTerminal; `CAST`, `(`, `)`, and `AS` are all stripped as punctuation so `castExpr.ChildNodes = [expr, dataType]`
- `Visit(SqlCastExpression)` added to `ISqlExpressionVisitor` and all six visitor implementations
- `SqlExpression` updated with new ctor, `CastExpr` property, `Accept`, `AssumeExpressionLikeness`, `ToExpressionString`, and `ToString` branches

## Test plan
- [ ] `Cast_ColumnToVarchar` — parses `CAST(order_id AS VARCHAR(50))`, checks column name and data type name/length
- [ ] `Cast_ColumnToInt` — parses `CAST(price AS INT)`, checks column name and no-length type
- [ ] `Cast_ToExpressionString_WithLength` — round-trips `CAST(order_id AS VARCHAR(50))`
- [ ] `Cast_ToExpressionString_NoParams` — round-trips `CAST(price AS INT)`
- [ ] All 145 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)