### PR TITLE
feat: support PostgreSQL RETURNING clause (#61)

### DIFF
--- a/src/Core/LogicalEntities/SqlDeleteDefinition.cs
+++ b/src/Core/LogicalEntities/SqlDeleteDefinition.cs
@@ -20,6 +20,11 @@ public class SqlDeleteDefinition
     /// </summary>
     public SqlOutputClause? OutputClause { get; set; }
 
+    /// <summary>
+    /// PostgreSQL RETURNING clause for capturing deleted rows.
+    /// </summary>
+    public SqlReturningClause? ReturningClause { get; set; }
+
     public void ResolveParameters(DbParameterCollection parameters) =>
         Accept(new ResolveParametersVisitor(parameters));
 

--- a/src/Core/LogicalEntities/SqlInsertDefinition.cs
+++ b/src/Core/LogicalEntities/SqlInsertDefinition.cs
@@ -33,6 +33,11 @@ public class SqlInsertDefinition
     /// </summary>
     public SqlOutputClause? OutputClause { get; set; }
 
+    /// <summary>
+    /// PostgreSQL RETURNING clause for capturing inserted rows.
+    /// </summary>
+    public SqlReturningClause? ReturningClause { get; set; }
+
     public void ResolveParameters(DbParameterCollection parameters) =>
         Accept(new ResolveParametersVisitor(parameters));
 

--- a/src/Core/LogicalEntities/SqlReturningClause.cs
+++ b/src/Core/LogicalEntities/SqlReturningClause.cs
@@ -1,0 +1,10 @@
+namespace SqlBuildingBlocks.LogicalEntities;
+
+/// <summary>
+/// Represents a PostgreSQL RETURNING clause that can contain multiple return items.
+/// Supports RETURNING *, RETURNING col1, col2, and RETURNING expr AS alias.
+/// </summary>
+public class SqlReturningClause
+{
+    public IList<SqlReturningItem> Items { get; } = new List<SqlReturningItem>();
+}

--- a/src/Core/LogicalEntities/SqlReturningItem.cs
+++ b/src/Core/LogicalEntities/SqlReturningItem.cs
@@ -1,0 +1,41 @@
+namespace SqlBuildingBlocks.LogicalEntities;
+
+/// <summary>
+/// Represents a single item in a PostgreSQL RETURNING clause.
+/// Can be a wildcard (*), a column reference, or an expression with an optional alias.
+/// </summary>
+public class SqlReturningItem
+{
+    /// <summary>
+    /// Creates a wildcard RETURNING item (RETURNING *).
+    /// </summary>
+    public SqlReturningItem()
+    {
+        IsWildcard = true;
+    }
+
+    /// <summary>
+    /// Creates a RETURNING item from an expression with an optional alias.
+    /// </summary>
+    public SqlReturningItem(SqlExpression expression, string? alias = null)
+    {
+        Expression = expression ?? throw new ArgumentNullException(nameof(expression));
+        Alias = alias;
+    }
+
+    /// <summary>
+    /// True if this item represents RETURNING *.
+    /// </summary>
+    public bool IsWildcard { get; }
+
+    /// <summary>
+    /// The expression being returned (column, function call, arithmetic, etc.).
+    /// Null when <see cref="IsWildcard"/> is true.
+    /// </summary>
+    public SqlExpression? Expression { get; }
+
+    /// <summary>
+    /// Optional alias (e.g., RETURNING id AS user_id).
+    /// </summary>
+    public string? Alias { get; }
+}

--- a/src/Core/LogicalEntities/SqlUpdateDefinition.cs
+++ b/src/Core/LogicalEntities/SqlUpdateDefinition.cs
@@ -23,6 +23,11 @@ public class SqlUpdateDefinition
     /// </summary>
     public SqlOutputClause? OutputClause { get; set; }
 
+    /// <summary>
+    /// PostgreSQL RETURNING clause for capturing updated rows.
+    /// </summary>
+    public SqlReturningClause? ReturningClause { get; set; }
+
     public void ResolveParameters(DbParameterCollection parameters) =>
         Accept(new ResolveParametersVisitor(parameters));
 

--- a/src/Grammars/PostgreSQL/DeleteStmt.cs
+++ b/src/Grammars/PostgreSQL/DeleteStmt.cs
@@ -1,0 +1,68 @@
+using Irony.Parsing;
+using SqlBuildingBlocks.LogicalEntities;
+
+namespace SqlBuildingBlocks.Grammars.PostgreSQL;
+
+/// <summary>
+/// PostgreSQL-specific DELETE statement that supports the full RETURNING clause.
+/// RETURNING appears after the WHERE clause.
+/// </summary>
+public class DeleteStmt : SqlBuildingBlocks.DeleteStmt
+{
+    private const string DeleteTargetOptTermName = "pgDeleteTargetOpt";
+
+    private readonly ReturningClauseOpt pgReturningClauseOpt;
+
+    public DeleteStmt(Grammar grammar, SqlBuildingBlocks.TableName tableName,
+                      WhereClauseOpt whereClauseOpt,
+                      SqlBuildingBlocks.ReturningClauseOpt returningClauseOpt,
+                      JoinChainOpt joinChainOpt,
+                      ReturningClauseOpt pgReturningClauseOpt)
+        : base(grammar, tableName, whereClauseOpt, returningClauseOpt, joinChainOpt)
+    {
+        this.pgReturningClauseOpt = pgReturningClauseOpt;
+
+        // Replace the base rule to use PostgreSQL RETURNING instead of the base one.
+        // Base Rule: DELETE + deleteTargetOpt + FROM + tableName + joinChainOpt + whereClauseOpt + returningClauseOpt
+        // New Rule:  DELETE + deleteTargetOpt + FROM + tableName + joinChainOpt + whereClauseOpt + pgReturningClauseOpt
+        var DELETE = grammar.ToTerm("DELETE");
+        var FROM = grammar.ToTerm("FROM");
+
+        var pgDeleteTargetOpt = new NonTerminal(DeleteTargetOptTermName);
+        pgDeleteTargetOpt.Rule = grammar.Empty | tableName;
+
+        Rule = DELETE + pgDeleteTargetOpt + FROM + tableName + joinChainOpt + whereClauseOpt + pgReturningClauseOpt;
+    }
+
+    public override void Update(ParseTreeNode deleteStmt, SqlDeleteDefinition sqlDeleteDefinition)
+    {
+        // Our rule: DELETE + deleteTargetOpt + FROM + tableName + joinChainOpt + whereClauseOpt + pgReturningClauseOpt
+        // Indices:   [0]     [1]              [2]    [3]          [4]            [5]               [6]
+
+        if (deleteStmt.Term.Name != TermName)
+        {
+            throw new ArgumentException(
+                $"Cannot create building block. The TermName for node is {deleteStmt.Term.Name} " +
+                $"which does not match {TermName}", nameof(deleteStmt));
+        }
+
+        var deleteTargetOpt = deleteStmt.ChildNodes[1];
+        var deleteSourceNode = deleteStmt.ChildNodes[3];
+
+        if (deleteTargetOpt.Term.Name == DeleteTargetOptTermName && deleteTargetOpt.ChildNodes.Count > 0)
+        {
+            sqlDeleteDefinition.Table = TableName.Create(deleteTargetOpt.ChildNodes[0]);
+            sqlDeleteDefinition.SourceTable = TableName.Create(deleteSourceNode);
+        }
+        else
+        {
+            sqlDeleteDefinition.Table = TableName.Create(deleteSourceNode);
+        }
+
+        AddJoins(sqlDeleteDefinition, deleteStmt.ChildNodes[4]);
+        sqlDeleteDefinition.WhereClause = WhereClauseOpt.Create(deleteStmt.ChildNodes[5]);
+
+        // Process the PostgreSQL RETURNING clause
+        sqlDeleteDefinition.ReturningClause = pgReturningClauseOpt.Create(deleteStmt.ChildNodes[6]);
+    }
+}

--- a/src/Grammars/PostgreSQL/InsertStmt.cs
+++ b/src/Grammars/PostgreSQL/InsertStmt.cs
@@ -4,7 +4,8 @@ using SqlBuildingBlocks.LogicalEntities;
 namespace SqlBuildingBlocks.Grammars.PostgreSQL;
 
 /// <summary>
-/// PostgreSQL-specific INSERT statement that supports ON CONFLICT DO UPDATE SET ... / DO NOTHING.
+/// PostgreSQL-specific INSERT statement that supports ON CONFLICT DO UPDATE SET ... / DO NOTHING
+/// and the RETURNING clause.
 /// Supports conflict targets: column list, ON CONSTRAINT, or no target.
 /// Supports optional WHERE clauses on both the conflict target and DO UPDATE action.
 /// </summary>
@@ -17,9 +18,19 @@ public class InsertStmt : SqlBuildingBlocks.InsertStmt
     private const string ConflictTargetWhereOptTermName = "conflictTargetWhereOpt";
     private const string ConflictUpdateWhereOptTermName = "conflictUpdateWhereOpt";
 
-    public InsertStmt(Grammar grammar, Id id, Expr expr, SelectStmt selectStmt)
+    private readonly ReturningClauseOpt? pgReturningClauseOpt;
+
+    public InsertStmt(Grammar grammar, Id id, SqlBuildingBlocks.Expr expr, SqlBuildingBlocks.SelectStmt selectStmt)
+        : this(grammar, id, expr, selectStmt, null)
+    {
+    }
+
+    public InsertStmt(Grammar grammar, Id id, SqlBuildingBlocks.Expr expr, SqlBuildingBlocks.SelectStmt selectStmt,
+                      ReturningClauseOpt? returningClauseOpt)
         : base(grammar, id, expr, selectStmt)
     {
+        pgReturningClauseOpt = returningClauseOpt;
+
         var ON = grammar.ToTerm("ON");
         var CONFLICT = grammar.ToTerm("CONFLICT");
         var CONSTRAINT = grammar.ToTerm("CONSTRAINT");
@@ -64,7 +75,10 @@ public class InsertStmt : SqlBuildingBlocks.InsertStmt
         var onConflictOpt = new NonTerminal(OnConflictOptTermName);
         onConflictOpt.Rule = grammar.Empty | ON + CONFLICT + conflictTarget + conflictAction;
 
-        Rule = Rule + onConflictOpt;
+        if (returningClauseOpt != null)
+            Rule = Rule + onConflictOpt + returningClauseOpt;
+        else
+            Rule = Rule + onConflictOpt;
 
         grammar.MarkPunctuation("(", ")");
     }
@@ -73,21 +87,46 @@ public class InsertStmt : SqlBuildingBlocks.InsertStmt
     {
         base.Update(insertStmt, sqlInsertDefinition);
 
-        // The ON CONFLICT clause is the last child node
-        var onConflictOpt = insertStmt.ChildNodes[insertStmt.ChildNodes.Count - 1];
-        if (onConflictOpt.Term.Name == OnConflictOptTermName && onConflictOpt.ChildNodes.Count > 0)
+        // Find the ON CONFLICT and RETURNING clauses at the end
+        // The last children are: ... + onConflictOpt [+ returningClauseOpt]
+        int lastIndex = insertStmt.ChildNodes.Count - 1;
+
+        if (pgReturningClauseOpt != null)
         {
-            var upsertClause = new SqlUpsertClause();
+            // returningClauseOpt is last, onConflictOpt is second to last
+            var returningNode = insertStmt.ChildNodes[lastIndex];
+            var onConflictOpt = insertStmt.ChildNodes[lastIndex - 1];
 
-            // Child layout: ON CONFLICT conflictTarget conflictAction
-            var conflictTarget = onConflictOpt.ChildNodes[2];
-            ParseConflictTarget(conflictTarget, upsertClause);
+            sqlInsertDefinition.ReturningClause = pgReturningClauseOpt.Create(returningNode);
 
-            var conflictAction = onConflictOpt.ChildNodes[3];
-            ParseConflictAction(conflictAction, upsertClause);
-
-            sqlInsertDefinition.UpsertClause = upsertClause;
+            if (onConflictOpt.Term.Name == OnConflictOptTermName && onConflictOpt.ChildNodes.Count > 0)
+            {
+                ParseOnConflict(onConflictOpt, sqlInsertDefinition);
+            }
         }
+        else
+        {
+            // No RETURNING, onConflictOpt is last
+            var onConflictOpt = insertStmt.ChildNodes[lastIndex];
+            if (onConflictOpt.Term.Name == OnConflictOptTermName && onConflictOpt.ChildNodes.Count > 0)
+            {
+                ParseOnConflict(onConflictOpt, sqlInsertDefinition);
+            }
+        }
+    }
+
+    private void ParseOnConflict(ParseTreeNode onConflictOpt, SqlInsertDefinition sqlInsertDefinition)
+    {
+        var upsertClause = new SqlUpsertClause();
+
+        // Child layout: ON CONFLICT conflictTarget conflictAction
+        var conflictTarget = onConflictOpt.ChildNodes[2];
+        ParseConflictTarget(conflictTarget, upsertClause);
+
+        var conflictAction = onConflictOpt.ChildNodes[3];
+        ParseConflictAction(conflictAction, upsertClause);
+
+        sqlInsertDefinition.UpsertClause = upsertClause;
     }
 
     private void ParseConflictTarget(ParseTreeNode conflictTarget, SqlUpsertClause upsertClause)

--- a/src/Grammars/PostgreSQL/ReturningClauseOpt.cs
+++ b/src/Grammars/PostgreSQL/ReturningClauseOpt.cs
@@ -1,0 +1,84 @@
+using Irony.Parsing;
+using SqlBuildingBlocks.Extensions;
+using SqlBuildingBlocks.LogicalEntities;
+using System.Reflection;
+
+namespace SqlBuildingBlocks.Grammars.PostgreSQL;
+
+/// <summary>
+/// PostgreSQL-specific RETURNING clause that supports the full syntax:
+/// RETURNING *, RETURNING col1, col2, RETURNING expr AS alias.
+/// </summary>
+public class ReturningClauseOpt : NonTerminal
+{
+    private const string ReturningItemTermName = "pgReturningItem";
+
+    private readonly SqlBuildingBlocks.Expr expr;
+    private readonly AliasOpt aliasOpt;
+
+    public ReturningClauseOpt(Grammar grammar, SqlBuildingBlocks.Expr expr, AliasOpt aliasOpt)
+        : base(TermName)
+    {
+        this.expr = expr ?? throw new ArgumentNullException(nameof(expr));
+        this.aliasOpt = aliasOpt ?? throw new ArgumentNullException(nameof(aliasOpt));
+
+        var RETURNING = grammar.ToTerm("RETURNING");
+        var STAR = grammar.ToTerm("*");
+
+        var returningItem = new NonTerminal(ReturningItemTermName);
+        returningItem.Rule = STAR | expr + aliasOpt;
+
+        var returningList = new NonTerminal("pgReturningList");
+        returningList.Rule = grammar.MakePlusRule(returningList, grammar.ToTerm(","), returningItem);
+
+        Rule = grammar.Empty | RETURNING + returningList;
+
+        grammar.MarkPunctuation(RETURNING);
+    }
+
+    public SqlReturningClause? Create(ParseTreeNode returningClauseOpt)
+    {
+        if (returningClauseOpt.ChildNodes.Count == 0)
+            return null;
+
+        var result = new SqlReturningClause();
+
+        // Child 0 is returningList (RETURNING is punctuated away)
+        var returningList = returningClauseOpt.ChildNodes[0];
+        foreach (ParseTreeNode itemNode in returningList.ChildNodes)
+        {
+            result.Items.Add(CreateReturningItem(itemNode));
+        }
+
+        return result;
+    }
+
+    private SqlReturningItem CreateReturningItem(ParseTreeNode itemNode)
+    {
+        // Check for wildcard (*)
+        if (itemNode.ChildNodes.Count == 1 &&
+            itemNode.ChildNodes[0].Token != null &&
+            itemNode.ChildNodes[0].Token.ValueString == "*")
+        {
+            return new SqlReturningItem();
+        }
+
+        // expr + aliasOpt
+        var exprNode = itemNode.ChildNodes[0];
+        var expression = expr.Create(exprNode);
+
+        string? alias = null;
+        if (itemNode.ChildNodes.Count > 1)
+        {
+            var aliasOptNode = itemNode.ChildNodes[1];
+            if (aliasOptNode.ChildNodes.Count > 0)
+            {
+                alias = aliasOpt.Create(aliasOptNode);
+            }
+        }
+
+        return new SqlReturningItem(expression, alias);
+    }
+
+    private static string TermName => MethodBase.GetCurrentMethod().DeclaringType.Name.CamelCase();
+}

--- a/src/Grammars/PostgreSQL/UpdateStmt.cs
+++ b/src/Grammars/PostgreSQL/UpdateStmt.cs
@@ -1,0 +1,88 @@
+using Irony.Parsing;
+using SqlBuildingBlocks.LogicalEntities;
+
+namespace SqlBuildingBlocks.Grammars.PostgreSQL;
+
+/// <summary>
+/// PostgreSQL-specific UPDATE statement that supports the full RETURNING clause.
+/// RETURNING appears after the WHERE clause.
+/// </summary>
+public class UpdateStmt : SqlBuildingBlocks.UpdateStmt
+{
+    private const string UpdateSourceOptTermName = "pgUpdateSourceOpt";
+
+    private readonly ReturningClauseOpt pgReturningClauseOpt;
+
+    public UpdateStmt(Grammar grammar, SqlBuildingBlocks.Expr expr, FuncCall funcCall,
+                      SqlBuildingBlocks.TableName tableName, WhereClauseOpt whereClauseOpt,
+                      SqlBuildingBlocks.ReturningClauseOpt returningClauseOpt,
+                      JoinChainOpt joinChainOpt, ReturningClauseOpt pgReturningClauseOpt)
+        : base(grammar, expr, funcCall, tableName, whereClauseOpt, returningClauseOpt, joinChainOpt)
+    {
+        this.pgReturningClauseOpt = pgReturningClauseOpt;
+
+        // Replace the base rule to use PostgreSQL RETURNING instead of the base one.
+        // Base Rule: UPDATE + tableName + joinChainOpt + SET + assignList + updateSourceOpt + whereClauseOpt + returningClauseOpt
+        // New Rule:  UPDATE + tableName + joinChainOpt + SET + assignList + updateSourceOpt + whereClauseOpt + pgReturningClauseOpt
+        var UPDATE = grammar.ToTerm("UPDATE");
+        var SET = grammar.ToTerm("SET");
+        var COMMA = grammar.ToTerm(",");
+        var FROM = grammar.ToTerm("FROM");
+
+        var pgAssignment = new NonTerminal("pgUpdateAssignment");
+        pgAssignment.Rule = expr.Id + "=" + expr;
+
+        var pgAssignList = new NonTerminal("pgUpdateAssignList");
+        pgAssignList.Rule = grammar.MakePlusRule(pgAssignList, COMMA, pgAssignment);
+
+        var pgUpdateSourceOpt = new NonTerminal(UpdateSourceOptTermName);
+        pgUpdateSourceOpt.Rule = grammar.Empty | FROM + tableName + joinChainOpt;
+
+        Rule = UPDATE + tableName + joinChainOpt + SET + pgAssignList + pgUpdateSourceOpt + whereClauseOpt + pgReturningClauseOpt;
+    }
+
+    public override void Update(ParseTreeNode updateStmt, SqlUpdateDefinition sqlUpdateDefinition)
+    {
+        // Our rule: UPDATE + tableName + joinChainOpt + SET + assignList + updateSourceOpt + whereClauseOpt + pgReturningClauseOpt
+        // Indices:   [0]     [1]         [2]           [3]   [4]          [5]               [6]               [7]
+
+        if (updateStmt.Term.Name != TermName)
+        {
+            throw new ArgumentException(
+                $"Cannot create building block. The TermName for node is {updateStmt.Term.Name} " +
+                $"which does not match {TermName}", nameof(updateStmt));
+        }
+
+        sqlUpdateDefinition.Table = TableName.Create(updateStmt.ChildNodes[1]);
+
+        AddJoins(sqlUpdateDefinition, updateStmt.ChildNodes[2]);
+
+        var assignList = updateStmt.ChildNodes[4];
+        foreach (ParseTreeNode assignment in assignList.ChildNodes)
+        {
+            var sqlColumn = Expr.Id.CreateColumn(assignment.ChildNodes[0]);
+            var sqlExpression = Expr.Create(assignment.ChildNodes[2]);
+            sqlUpdateDefinition.Assignments.Add(new SqlAssignment(sqlColumn, sqlExpression));
+        }
+
+        AddSource(sqlUpdateDefinition, updateStmt.ChildNodes[5]);
+
+        sqlUpdateDefinition.WhereClause = WhereClauseOpt.Create(updateStmt.ChildNodes[6]);
+
+        // Process the PostgreSQL RETURNING clause
+        sqlUpdateDefinition.ReturningClause = pgReturningClauseOpt.Create(updateStmt.ChildNodes[7]);
+    }
+
+    private new void AddSource(SqlUpdateDefinition sqlUpdateDefinition, ParseTreeNode updateSourceOptNode)
+    {
+        if (updateSourceOptNode.Term.Name != UpdateSourceOptTermName || updateSourceOptNode.ChildNodes.Count == 0)
+            return;
+
+        sqlUpdateDefinition.SourceTable = TableName.Create(updateSourceOptNode.ChildNodes[1]);
+
+        foreach (var join in JoinChainOpt.Create(updateSourceOptNode.ChildNodes[2]))
+        {
+            sqlUpdateDefinition.Joins.Add(join);
+        }
+    }
+}

--- a/tests/Grammars/PostgreSQL.Tests/ReturningClauseTests.cs
+++ b/tests/Grammars/PostgreSQL.Tests/ReturningClauseTests.cs
@@ -1,0 +1,431 @@
+using Irony.Parsing;
+using SqlBuildingBlocks.Core.Tests.Utils;
+using SqlBuildingBlocks.LogicalEntities;
+using Xunit;
+
+namespace SqlBuildingBlocks.Grammars.PostgreSQL.Tests;
+
+public class ReturningClauseTests
+{
+    #region Test Grammars
+
+    private class InsertTestGrammar : Grammar
+    {
+        public InsertTestGrammar() : base(false) // SQL is case insensitive
+        {
+            SimpleId simpleId = new(this);
+            AliasOpt aliasOpt = new(this, simpleId);
+            Id id = new(this, simpleId);
+            LiteralValue literalValue = new(this);
+            TableName tableName = new(this, aliasOpt, id);
+            Parameter parameter = new(this);
+            PostgreSQL.Expr expr = new(this, id, literalValue, parameter);
+            FuncCall funcCall = new(this, id, expr);
+            JoinChainOpt joinChainOpt = new(this, tableName, expr);
+            WhereClauseOpt whereClauseOpt = new(this, expr);
+            OrderByList orderByList = new(this, id);
+            SelectStmt selectStmt = new(this, id, expr, aliasOpt, tableName, joinChainOpt, orderByList, whereClauseOpt, funcCall);
+
+            expr.InitializeRule(selectStmt, funcCall);
+
+            PostgreSQL.ReturningClauseOpt returningClauseOpt = new(this, expr, aliasOpt);
+            PostgreSQL.InsertStmt insertStmt = new(this, id, expr, selectStmt, returningClauseOpt);
+
+            Root = insertStmt;
+        }
+
+        public SqlInsertDefinition Create(ParseTreeNode insertStmt) =>
+            ((PostgreSQL.InsertStmt)Root).Create(insertStmt);
+    }
+
+    private class UpdateTestGrammar : Grammar
+    {
+        public UpdateTestGrammar() : base(false)
+        {
+            SimpleId simpleId = new(this);
+            AliasOpt aliasOpt = new(this, simpleId);
+            Id id = new(this, simpleId);
+            LiteralValue literalValue = new(this);
+            TableName tableName = new(this, aliasOpt, id);
+            Parameter parameter = new(this);
+            PostgreSQL.Expr expr = new(this, id, literalValue, parameter);
+            FuncCall funcCall = new(this, id, expr);
+            JoinChainOpt joinChainOpt = new(this, tableName, expr);
+            WhereClauseOpt whereClauseOpt = new(this, expr);
+            SqlBuildingBlocks.ReturningClauseOpt baseReturningClauseOpt = new(this, id);
+            PostgreSQL.ReturningClauseOpt pgReturningClauseOpt = new(this, expr, aliasOpt);
+            PostgreSQL.UpdateStmt updateStmt = new(this, expr, funcCall, tableName, whereClauseOpt,
+                baseReturningClauseOpt, joinChainOpt, pgReturningClauseOpt);
+
+            OrderByList orderByList = new(this, id);
+            SelectStmt selectStmt = new(this, id, expr, aliasOpt, tableName, joinChainOpt, orderByList, whereClauseOpt, funcCall);
+
+            expr.InitializeRule(selectStmt, funcCall);
+
+            Root = updateStmt;
+        }
+
+        public SqlUpdateDefinition Create(ParseTreeNode updateStmt) =>
+            ((PostgreSQL.UpdateStmt)Root).Create(updateStmt);
+    }
+
+    private class DeleteTestGrammar : Grammar
+    {
+        public DeleteTestGrammar() : base(false)
+        {
+            SimpleId simpleId = new(this);
+            AliasOpt aliasOpt = new(this, simpleId);
+            Id id = new(this, simpleId);
+            LiteralValue literalValue = new(this);
+            TableName tableName = new(this, aliasOpt, id);
+            Parameter parameter = new(this);
+            PostgreSQL.Expr expr = new(this, id, literalValue, parameter);
+            JoinChainOpt joinChainOpt = new(this, tableName, expr);
+            WhereClauseOpt whereClauseOpt = new(this, expr);
+            SqlBuildingBlocks.ReturningClauseOpt baseReturningClauseOpt = new(this, id);
+            PostgreSQL.ReturningClauseOpt pgReturningClauseOpt = new(this, expr, aliasOpt);
+            PostgreSQL.DeleteStmt deleteStmt = new(this, tableName, whereClauseOpt,
+                baseReturningClauseOpt, joinChainOpt, pgReturningClauseOpt);
+
+            FuncCall funcCall = new(this, id, expr);
+            OrderByList orderByList = new(this, id);
+            SelectStmt selectStmt = new(this, id, expr, aliasOpt, tableName, joinChainOpt, orderByList, whereClauseOpt, funcCall);
+
+            expr.InitializeRule(selectStmt, funcCall);
+
+            Root = deleteStmt;
+        }
+
+        public SqlDeleteDefinition Create(ParseTreeNode deleteStmt) =>
+            ((PostgreSQL.DeleteStmt)Root).Create(deleteStmt);
+    }
+
+    #endregion
+
+    #region INSERT with RETURNING
+
+    [Fact]
+    public void Insert_Returning_Star()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (id, name) VALUES (1, 'Alice') RETURNING *");
+
+        var insertDef = grammar.Create(node);
+
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Single(insertDef.ReturningClause!.Items);
+        Assert.True(insertDef.ReturningClause.Items[0].IsWildcard);
+
+        // Verify the rest of the INSERT parsed correctly
+        Assert.Equal("users", insertDef.Table!.TableName);
+        Assert.Equal(2, insertDef.Columns.Count);
+        Assert.NotNull(insertDef.Values);
+        Assert.Single(insertDef.Values!);
+    }
+
+    [Fact]
+    public void Insert_Returning_SingleColumn()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com') RETURNING id");
+
+        var insertDef = grammar.Create(node);
+
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Single(insertDef.ReturningClause!.Items);
+        var item = insertDef.ReturningClause.Items[0];
+        Assert.False(item.IsWildcard);
+        Assert.NotNull(item.Expression);
+        Assert.NotNull(item.Expression!.Column);
+        Assert.Equal("id", item.Expression.Column!.ColumnName);
+        Assert.Null(item.Alias);
+    }
+
+    [Fact]
+    public void Insert_Returning_MultipleColumns()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com') RETURNING id, name, email");
+
+        var insertDef = grammar.Create(node);
+
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Equal(3, insertDef.ReturningClause!.Items.Count);
+
+        Assert.Equal("id", insertDef.ReturningClause.Items[0].Expression!.Column!.ColumnName);
+        Assert.Equal("name", insertDef.ReturningClause.Items[1].Expression!.Column!.ColumnName);
+        Assert.Equal("email", insertDef.ReturningClause.Items[2].Expression!.Column!.ColumnName);
+    }
+
+    [Fact]
+    public void Insert_Returning_WithAlias()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (name) VALUES ('Alice') RETURNING id AS user_id");
+
+        var insertDef = grammar.Create(node);
+
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Single(insertDef.ReturningClause!.Items);
+        var item = insertDef.ReturningClause.Items[0];
+        Assert.False(item.IsWildcard);
+        Assert.NotNull(item.Expression);
+        Assert.Equal("id", item.Expression!.Column!.ColumnName);
+        Assert.Equal("user_id", item.Alias);
+    }
+
+    [Fact]
+    public void Insert_Without_Returning()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (id, name) VALUES (1, 'Alice')");
+
+        var insertDef = grammar.Create(node);
+
+        Assert.Null(insertDef.ReturningClause);
+        Assert.Equal("users", insertDef.Table!.TableName);
+    }
+
+    [Fact]
+    public void Insert_OnConflict_With_Returning()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (id, name) VALUES (1, 'Alice') ON CONFLICT (id) DO NOTHING RETURNING *");
+
+        var insertDef = grammar.Create(node);
+
+        // Verify RETURNING
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Single(insertDef.ReturningClause!.Items);
+        Assert.True(insertDef.ReturningClause.Items[0].IsWildcard);
+
+        // Verify ON CONFLICT
+        Assert.NotNull(insertDef.UpsertClause);
+        Assert.Equal(SqlUpsertAction.DoNothing, insertDef.UpsertClause.Action);
+        Assert.Single(insertDef.UpsertClause.ConflictColumns);
+        Assert.Equal("id", insertDef.UpsertClause.ConflictColumns[0].ColumnName);
+    }
+
+    [Fact]
+    public void Insert_OnConflictDoUpdate_With_Returning_MultipleColumns()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name RETURNING id, name");
+
+        var insertDef = grammar.Create(node);
+
+        // Verify RETURNING
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Equal(2, insertDef.ReturningClause!.Items.Count);
+        Assert.Equal("id", insertDef.ReturningClause.Items[0].Expression!.Column!.ColumnName);
+        Assert.Equal("name", insertDef.ReturningClause.Items[1].Expression!.Column!.ColumnName);
+
+        // Verify ON CONFLICT
+        Assert.NotNull(insertDef.UpsertClause);
+        Assert.Equal(SqlUpsertAction.Update, insertDef.UpsertClause.Action);
+    }
+
+    [Fact]
+    public void Insert_Returning_CaseInsensitive()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "insert into users (id, name) values (1, 'Alice') returning *");
+
+        var insertDef = grammar.Create(node);
+
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Single(insertDef.ReturningClause!.Items);
+        Assert.True(insertDef.ReturningClause.Items[0].IsWildcard);
+    }
+
+    #endregion
+
+    #region UPDATE with RETURNING
+
+    [Fact]
+    public void Update_Returning_Star()
+    {
+        UpdateTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "UPDATE users SET name = 'Bob' RETURNING *");
+
+        var updateDef = grammar.Create(node);
+
+        Assert.NotNull(updateDef.ReturningClause);
+        Assert.Single(updateDef.ReturningClause!.Items);
+        Assert.True(updateDef.ReturningClause.Items[0].IsWildcard);
+
+        // Verify rest of UPDATE parsed correctly
+        Assert.Equal("users", updateDef.Table!.TableName);
+        Assert.Single(updateDef.Assignments);
+    }
+
+    [Fact]
+    public void Update_Returning_MultipleColumns()
+    {
+        UpdateTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "UPDATE users SET name = 'Bob' WHERE id = 1 RETURNING id, name, email");
+
+        var updateDef = grammar.Create(node);
+
+        Assert.NotNull(updateDef.ReturningClause);
+        Assert.Equal(3, updateDef.ReturningClause!.Items.Count);
+        Assert.Equal("id", updateDef.ReturningClause.Items[0].Expression!.Column!.ColumnName);
+        Assert.Equal("name", updateDef.ReturningClause.Items[1].Expression!.Column!.ColumnName);
+        Assert.Equal("email", updateDef.ReturningClause.Items[2].Expression!.Column!.ColumnName);
+        Assert.NotNull(updateDef.WhereClause);
+    }
+
+    [Fact]
+    public void Update_Returning_WithAlias()
+    {
+        UpdateTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "UPDATE products SET price = 999 RETURNING id AS product_id, price AS new_price");
+
+        var updateDef = grammar.Create(node);
+
+        Assert.NotNull(updateDef.ReturningClause);
+        Assert.Equal(2, updateDef.ReturningClause!.Items.Count);
+
+        Assert.Equal("id", updateDef.ReturningClause.Items[0].Expression!.Column!.ColumnName);
+        Assert.Equal("product_id", updateDef.ReturningClause.Items[0].Alias);
+
+        Assert.Equal("price", updateDef.ReturningClause.Items[1].Expression!.Column!.ColumnName);
+        Assert.Equal("new_price", updateDef.ReturningClause.Items[1].Alias);
+    }
+
+    [Fact]
+    public void Update_Without_Returning()
+    {
+        UpdateTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "UPDATE users SET name = 'Bob' WHERE id = 1");
+
+        var updateDef = grammar.Create(node);
+
+        Assert.Null(updateDef.ReturningClause);
+        Assert.Equal("users", updateDef.Table!.TableName);
+    }
+
+    #endregion
+
+    #region DELETE with RETURNING
+
+    [Fact]
+    public void Delete_Returning_Star()
+    {
+        DeleteTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "DELETE FROM users WHERE id = 1 RETURNING *");
+
+        var deleteDef = grammar.Create(node);
+
+        Assert.NotNull(deleteDef.ReturningClause);
+        Assert.Single(deleteDef.ReturningClause!.Items);
+        Assert.True(deleteDef.ReturningClause.Items[0].IsWildcard);
+
+        Assert.NotNull(deleteDef.WhereClause);
+        Assert.Equal("users", deleteDef.Table!.TableName);
+    }
+
+    [Fact]
+    public void Delete_Returning_MultipleColumns()
+    {
+        DeleteTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "DELETE FROM orders WHERE status = 'cancelled' RETURNING id, customer_id, amount");
+
+        var deleteDef = grammar.Create(node);
+
+        Assert.NotNull(deleteDef.ReturningClause);
+        Assert.Equal(3, deleteDef.ReturningClause!.Items.Count);
+        Assert.Equal("id", deleteDef.ReturningClause.Items[0].Expression!.Column!.ColumnName);
+        Assert.Equal("customer_id", deleteDef.ReturningClause.Items[1].Expression!.Column!.ColumnName);
+        Assert.Equal("amount", deleteDef.ReturningClause.Items[2].Expression!.Column!.ColumnName);
+    }
+
+    [Fact]
+    public void Delete_Returning_WithAlias()
+    {
+        DeleteTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "DELETE FROM users WHERE id = 1 RETURNING id AS deleted_id, name AS deleted_name");
+
+        var deleteDef = grammar.Create(node);
+
+        Assert.NotNull(deleteDef.ReturningClause);
+        Assert.Equal(2, deleteDef.ReturningClause!.Items.Count);
+
+        Assert.Equal("id", deleteDef.ReturningClause.Items[0].Expression!.Column!.ColumnName);
+        Assert.Equal("deleted_id", deleteDef.ReturningClause.Items[0].Alias);
+
+        Assert.Equal("name", deleteDef.ReturningClause.Items[1].Expression!.Column!.ColumnName);
+        Assert.Equal("deleted_name", deleteDef.ReturningClause.Items[1].Alias);
+    }
+
+    [Fact]
+    public void Delete_Without_Returning()
+    {
+        DeleteTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "DELETE FROM users WHERE id = 1");
+
+        var deleteDef = grammar.Create(node);
+
+        Assert.Null(deleteDef.ReturningClause);
+        Assert.Equal("users", deleteDef.Table!.TableName);
+    }
+
+    [Fact]
+    public void Delete_Returning_SingleColumn()
+    {
+        DeleteTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "DELETE FROM users RETURNING id");
+
+        var deleteDef = grammar.Create(node);
+
+        Assert.NotNull(deleteDef.ReturningClause);
+        Assert.Single(deleteDef.ReturningClause!.Items);
+        var item = deleteDef.ReturningClause.Items[0];
+        Assert.False(item.IsWildcard);
+        Assert.Equal("id", item.Expression!.Column!.ColumnName);
+    }
+
+    #endregion
+
+    #region RETURNING with expressions
+
+    [Fact]
+    public void Insert_Returning_QualifiedColumn()
+    {
+        InsertTestGrammar grammar = new();
+        var node = GrammarParser.Parse(grammar,
+            "INSERT INTO users (name) VALUES ('Alice') RETURNING users.id, users.name");
+
+        var insertDef = grammar.Create(node);
+
+        Assert.NotNull(insertDef.ReturningClause);
+        Assert.Equal(2, insertDef.ReturningClause!.Items.Count);
+
+        var item1 = insertDef.ReturningClause.Items[0];
+        Assert.Equal("users", item1.Expression!.Column!.TableName);
+        Assert.Equal("id", item1.Expression.Column.ColumnName);
+
+        var item2 = insertDef.ReturningClause.Items[1];
+        Assert.Equal("users", item2.Expression!.Column!.TableName);
+        Assert.Equal("name", item2.Expression.Column.ColumnName);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add full PostgreSQL RETURNING clause support for INSERT, UPDATE, and DELETE statements
- New model classes `SqlReturningClause` and `SqlReturningItem` represent the clause structure (wildcard, expressions with optional aliases)
- New PostgreSQL grammar classes: `ReturningClauseOpt`, `UpdateStmt`, `DeleteStmt`; updated `InsertStmt` to support RETURNING alongside ON CONFLICT
- 18 new tests covering all RETURNING variants (*, single/multiple columns, aliases, qualified columns, combined with ON CONFLICT)

Closes #61

## Test plan

- [x] All 87 PostgreSQL tests pass (18 new RETURNING tests + 12 existing ON CONFLICT tests preserved)
- [x] All 292 Core tests pass (no regressions)
- [x] All 97 SQL Server tests pass (OUTPUT clause unaffected)
- [x] All 71 MySQL tests pass (no regressions)
- [x] `dotnet build SqlBuildingBlocks.sln` succeeds with 0 errors, 0 warnings

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)