### PR TITLE
feat: throw NotSupportedException for unexecuted SQL features (#149)

### DIFF
--- a/src/Core/QueryProcessing/QueryEngine.cs
+++ b/src/Core/QueryProcessing/QueryEngine.cs
@@ -60,6 +60,10 @@ public class QueryEngine : IQueryEngine
 
     private (ProcessingState processingState, IEnumerable<DataRow> SelectRows) QueryInternal()
     {
+        // Guard against SQL features that are parsed but not yet executed correctly.
+        // Silently ignoring these produces wrong results, so throw early.
+        ThrowIfUnsupportedFeatures();
+
         ProcessingState processingState = new();
         DetermineColumns(processingState);
 
@@ -1191,5 +1195,23 @@ public class QueryEngine : IQueryEngine
         }
 
         processingState.QueryOutput.Columns.Add(newColumn);
+    }
+
+    private void ThrowIfUnsupportedFeatures()
+    {
+        if (sqlSelectDefinition.Ctes.Count > 0)
+            throw new NotSupportedException("Common Table Expression (WITH clause) execution is not yet supported.");
+
+        if (sqlSelectDefinition.SetOperations.Count > 0)
+            throw new NotSupportedException("Set operation (UNION, INTERSECT, EXCEPT) execution is not yet supported.");
+
+        foreach (var col in sqlSelectDefinition.Columns)
+        {
+            if (col is SqlAggregate agg && agg.IsWindowFunction)
+                throw new NotSupportedException($"Window aggregate '{agg.AggregateName}() OVER(...)' execution is not yet supported.");
+
+            if (col is SqlFunctionColumn funcCol && funcCol.Function.IsWindowFunction)
+                throw new NotSupportedException($"Window function '{funcCol.Function.FunctionName}() OVER(...)' execution is not yet supported.");
+        }
     }
 }

--- a/tests/Core.Tests/QueryProcessing/QueryEngineTests.cs
+++ b/tests/Core.Tests/QueryProcessing/QueryEngineTests.cs
@@ -2215,4 +2215,110 @@ public class QueryEngineTests
     }
 
     #endregion
+
+    #region Unsupported Feature Guards
+
+    [Fact]
+    public void Query_WithCte_ThrowsNotSupportedException()
+    {
+        const string databaseName = "MyDB";
+
+        SqlSelectDefinition sqlSelect = new();
+        sqlSelect.Columns.Add(new SqlColumn(databaseName, "Employees", "Name"));
+        sqlSelect.Table = new SqlTable(databaseName, "Employees");
+
+        // Add a CTE: WITH cte AS (SELECT ...)
+        var cteSelect = new SqlSelectDefinition();
+        cteSelect.Columns.Add(new SqlColumn(databaseName, "Employees", "Name"));
+        sqlSelect.Ctes.Add(new SqlCteDefinition("cte", cteSelect));
+
+        DataSet dataSet = new(databaseName);
+        DataTable employees = new("Employees");
+        employees.Columns.Add("Name", typeof(string));
+        employees.Rows.Add("Alice");
+        dataSet.Tables.Add(employees);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+
+        var ex = Assert.Throws<NotSupportedException>(() => queryEngine.QueryAsDataTable());
+        Assert.Contains("Common Table Expression", ex.Message);
+    }
+
+    [Fact]
+    public void Query_WithUnion_ThrowsNotSupportedException()
+    {
+        const string databaseName = "MyDB";
+
+        SqlSelectDefinition sqlSelect = new();
+        sqlSelect.Columns.Add(new SqlColumn(databaseName, "Employees", "Name"));
+        sqlSelect.Table = new SqlTable(databaseName, "Employees");
+
+        // Add a UNION: SELECT ... UNION SELECT ...
+        var rightSelect = new SqlSelectDefinition();
+        rightSelect.Columns.Add(new SqlColumn(databaseName, "Contractors", "Name"));
+        sqlSelect.SetOperations.Add(new SqlSetOperation(SqlSetOperator.Union, rightSelect));
+
+        DataSet dataSet = new(databaseName);
+        DataTable employees = new("Employees");
+        employees.Columns.Add("Name", typeof(string));
+        employees.Rows.Add("Alice");
+        dataSet.Tables.Add(employees);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+
+        var ex = Assert.Throws<NotSupportedException>(() => queryEngine.QueryAsDataTable());
+        Assert.Contains("Set operation", ex.Message);
+    }
+
+    [Fact]
+    public void Query_WithWindowAggregate_ThrowsNotSupportedException()
+    {
+        const string databaseName = "MyDB";
+
+        SqlSelectDefinition sqlSelect = new();
+        var agg = new SqlAggregate("SUM", new SqlExpression(new SqlColumnRef(null, null, "Salary")))
+        {
+            WindowSpecification = new SqlWindowSpecification()
+        };
+        sqlSelect.Columns.Add(agg);
+        sqlSelect.Table = new SqlTable(databaseName, "Employees");
+
+        DataSet dataSet = new(databaseName);
+        DataTable employees = new("Employees");
+        employees.Columns.Add("Salary", typeof(decimal));
+        employees.Rows.Add(50000m);
+        dataSet.Tables.Add(employees);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+
+        var ex = Assert.Throws<NotSupportedException>(() => queryEngine.QueryAsDataTable());
+        Assert.Contains("Window aggregate", ex.Message);
+    }
+
+    [Fact]
+    public void Query_WithWindowFunction_ThrowsNotSupportedException()
+    {
+        const string databaseName = "MyDB";
+
+        SqlSelectDefinition sqlSelect = new();
+        var func = new SqlFunction("ROW_NUMBER")
+        {
+            WindowSpecification = new SqlWindowSpecification()
+        };
+        sqlSelect.Columns.Add(new SqlFunctionColumn(func));
+        sqlSelect.Table = new SqlTable(databaseName, "Employees");
+
+        DataSet dataSet = new(databaseName);
+        DataTable employees = new("Employees");
+        employees.Columns.Add("Name", typeof(string));
+        employees.Rows.Add("Alice");
+        dataSet.Tables.Add(employees);
+
+        QueryEngine queryEngine = new(new DataSet[] { dataSet }, sqlSelect);
+
+        var ex = Assert.Throws<NotSupportedException>(() => queryEngine.QueryAsDataTable());
+        Assert.Contains("Window function", ex.Message);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Throw NotSupportedException for SQL features that aren't yet executed by QueryEngine

## Test plan
- [x] 649 tests pass (394 core + 71 MySQL + 87 PostgreSQL + 97 SQLServer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)